### PR TITLE
#5 Let Spring create KatharsisInvokerBuilder

### DIFF
--- a/src/main/java/io/katharsis/spring/KatharsisFilter.java
+++ b/src/main/java/io/katharsis/spring/KatharsisFilter.java
@@ -9,6 +9,7 @@ import io.katharsis.servlet.ServletKatharsisInvokerContext;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 
 import javax.servlet.http.HttpServletRequest;
@@ -32,6 +33,9 @@ public class KatharsisFilter extends SampleKatharsisFilter implements BeanFactor
     private String pathPrefix;
     private ConfigurableBeanFactory beanFactory;
 
+    @Autowired
+    private KatharsisInvokerBuilder builder;
+
     @Override
     public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
         if (beanFactory instanceof ConfigurableBeanFactory) {
@@ -41,8 +45,6 @@ public class KatharsisFilter extends SampleKatharsisFilter implements BeanFactor
 
     @Override
     protected KatharsisInvokerBuilder createKatharsisInvokerBuilder() {
-        KatharsisInvokerBuilder builder = new KatharsisInvokerBuilder();
-
         builder.resourceSearchPackage(resourceSearchPackage)
             .resourceDefaultDomain(resourceDomain)
             .jsonServiceLocator(new JsonServiceLocator() {

--- a/src/main/java/io/katharsis/spring/boot/KatharsisConfig.java
+++ b/src/main/java/io/katharsis/spring/boot/KatharsisConfig.java
@@ -1,5 +1,6 @@
 package io.katharsis.spring.boot;
 
+import io.katharsis.invoker.KatharsisInvokerBuilder;
 import io.katharsis.spring.KatharsisFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -22,5 +23,10 @@ public class KatharsisConfig {
         filter.setResourceDomain(properties.getDomainName());
         filter.setPathPrefix(properties.getPathPrefix());
         return filter;
+    }
+
+    @Bean
+    public KatharsisInvokerBuilder katharsisInvokerBuilder() {
+    	return new KatharsisInvokerBuilder();
     }
 }


### PR DESCRIPTION
This allows me to use a custom `KatharsisInvokerBuilder` (which then allows me to customize the ObjectMapper) like this
```
@Configuration
@EnableConfigurationProperties(KatharsisSpringBootProperties.class)
@Import(io.katharsis.spring.boot.KatharsisConfig.class)
public class KatharsisConfig {

	@Bean
	public KatharsisInvokerBuilder katharsisInvokerBuilder() {
		return new CustomKatharsisInvokerBuilder();
	}

}
```