### PR TITLE
Ignore error in media type parsing

### DIFF
--- a/src/main/java/io/katharsis/spring/KatharsisFilterV2.java
+++ b/src/main/java/io/katharsis/spring/KatharsisFilterV2.java
@@ -200,10 +200,14 @@ public class KatharsisFilterV2 implements Filter, BeanFactoryAware {
             MediaType acceptableType;
 
             for (String mediaTypeItem : accepts) {
-                acceptableType = MediaType.parse(mediaTypeItem.trim());
+                try {
+                    acceptableType = MediaType.parse(mediaTypeItem.trim());
 
-                if (JsonApiMediaType.isCompatibleMediaType(acceptableType)) {
-                    return true;
+                    if (JsonApiMediaType.isCompatibleMediaType(acceptableType)) {
+                        return true;
+                    }
+                } catch (Exception e) {
+                    continue;
                 }
             }
         }


### PR DESCRIPTION
Unsupported accept headers are causing katharsis to stop processing the request.

This change make katharsis to ignore those headers.

-H 'Accept: application/vnd.api+json' -> Works
-H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,​/​;q=0.8' -> Error

java.lang.IllegalStateException: null
at com.google.common.base.Preconditions.checkState(Preconditions.java:134) ~[guava-15.0.jar:na]
at com.google.common.net.MediaType$Tokenizer.consumeToken(MediaType.java:611) ~[guava-15.0.jar:na]
at com.google.common.net.MediaType.parse(MediaType.java:559) ~[guava-15.0.jar:na]
at io.katharsis.spring.KatharsisFilterV2.isAcceptableMediaType(KatharsisFilterV2.java:203) ~[katharsis-spring-2.2.0.jar:na]
at io.katharsis.spring.KatharsisFilterV2.invoke(KatharsisFilterV2.java:100) ~[katharsis-spring-2.2.0.jar:na]
at io.katharsis.spring.KatharsisFilterV2.doFilter(KatharsisFilterV2.java:81) ~[katharsis-spring-2.2.0.jar:na]
