### PR TITLE
Use a separate Filter to handle errors anywhere in KatharsisFilterV2

### DIFF
--- a/src/main/java/io/katharsis/spring/ErrorHandlerFilter.java
+++ b/src/main/java/io/katharsis/spring/ErrorHandlerFilter.java
@@ -1,0 +1,56 @@
+package io.katharsis.spring;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.katharsis.errorhandling.ErrorResponse;
+import io.katharsis.errorhandling.mapper.ExceptionMapperRegistry;
+import io.katharsis.errorhandling.mapper.JsonApiExceptionMapper;
+import io.katharsis.invoker.KatharsisInvokerException;
+import io.katharsis.utils.java.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.annotation.Priority;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+@Priority(10)
+public class ErrorHandlerFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(ErrorHandlerFilter.class);
+
+    private ObjectMapper objectMapper;
+    private ExceptionMapperRegistry exceptionMapperRegistry;
+
+    public ErrorHandlerFilter(ObjectMapper objectMapper, ExceptionMapperRegistry exceptionMapperRegistry) {
+        this.objectMapper = objectMapper;
+        this.exceptionMapperRegistry = exceptionMapperRegistry;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (KatharsisInvokerException e) {
+            Optional<JsonApiExceptionMapper> mapper = exceptionMapperRegistry.findMapperFor(e.getCause().getClass());
+            if (!mapper.isPresent()) {
+                throw e;
+            }
+            ErrorResponse errorResponse = mapper.get().toErrorResponse(e.getCause());
+            response.setStatus(errorResponse.getHttpStatus());
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            objectMapper.writeValue(baos, errorResponse);
+
+            try (OutputStream out = response.getOutputStream()) {
+                out.write(baos.toByteArray());
+                out.flush();
+            }
+            log.warn("Katharsis Invoker exception.", e);
+        }
+    }
+}

--- a/src/main/java/io/katharsis/spring/KatharsisFilterV2.java
+++ b/src/main/java/io/katharsis/spring/KatharsisFilterV2.java
@@ -25,12 +25,14 @@ import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 
+import javax.annotation.Priority;
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.*;
 import java.util.*;
 
+@Priority(20)
 public class KatharsisFilterV2 implements Filter, BeanFactoryAware {
 
     private static final Logger log = LoggerFactory.getLogger(KatharsisFilterV2.class);
@@ -76,15 +78,7 @@ public class KatharsisFilterV2 implements Filter, BeanFactoryAware {
             HttpServletResponse response = (HttpServletResponse) res;
             req.setCharacterEncoding("UTF-8");
 
-            boolean passToFilters = false;
-            try {
-                passToFilters = invoke(request, response);
-            } catch (KatharsisInvokerException e) {
-                log.warn("Katharsis Invoker exception.", e);
-                response.setStatus(e.getStatusCode());
-            } catch (Exception e) {
-                throw new ServletException("Katharsis invocation failed.", e);
-            }
+            boolean passToFilters = invoke(request, response);
             if (passToFilters) {
                 chain.doFilter(req, res);
             }

--- a/src/main/java/io/katharsis/spring/boot/KatharsisConfigV2.java
+++ b/src/main/java/io/katharsis/spring/boot/KatharsisConfigV2.java
@@ -17,6 +17,7 @@ import io.katharsis.resource.field.ResourceFieldNameTransformer;
 import io.katharsis.resource.information.ResourceInformationBuilder;
 import io.katharsis.resource.registry.ResourceRegistry;
 import io.katharsis.resource.registry.ResourceRegistryBuilder;
+import io.katharsis.spring.ErrorHandlerFilter;
 import io.katharsis.spring.KatharsisFilterV2;
 import io.katharsis.spring.SpringServiceLocator;
 import io.katharsis.utils.parser.TypeParser;
@@ -47,6 +48,9 @@ public class KatharsisConfigV2 {
     private ResourceRegistry resourceRegistry;
 
     @Autowired
+    private ExceptionMapperRegistry exceptionMapperRegistry;
+
+    @Autowired
     private RequestDispatcher requestDispatcher;
 
     @Autowired
@@ -61,6 +65,9 @@ public class KatharsisConfigV2 {
         return new KatharsisFilterV2(objectMapper, queryParamsBuilder, resourceRegistry, requestDispatcher,
                 properties.getPathPrefix());
     }
+
+    @Bean
+    public Filter errorHandlerFilter() {
+        return new ErrorHandlerFilter(objectMapper, exceptionMapperRegistry);
+    }
 }
-
-


### PR DESCRIPTION
I made this change because I was getting exceptions thrown when KatharsisFilterV2's dispatchRequest method called `objectMapper.writeValue(baos, katharsisResponse);`, and that resulted in a 500 with no response body.

If an error occurred while serializing the entity there was no way to handle it, so I brought the error handler up to a level where it could catch anything that went wrong in the application.